### PR TITLE
Fixing NPE caused by ecore containing EAnnotation types

### DIFF
--- a/solutions/EcoreImport/models/EcoreImport.plugin.mps
+++ b/solutions/EcoreImport/models/EcoreImport.plugin.mps
@@ -66,7 +66,7 @@
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
-      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="ng" index="2tJIrI" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
         <child id="1076505808688" name="condition" index="2$JKZa" />
       </concept>
@@ -299,10 +299,10 @@
       </concept>
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
-      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="ng" index="3oM_SD">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
         <property id="155656958578482949" name="value" index="3oM_SC" />
       </concept>
-      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="ng" index="1PaTwC">
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
         <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
@@ -1514,6 +1514,30 @@
           </node>
         </node>
         <node concept="3clFbH" id="2Ttkg9nVYCb" role="3cqZAp" />
+        <node concept="3clFbJ" id="YzuRU63$pr" role="3cqZAp">
+          <node concept="3clFbS" id="YzuRU63$ps" role="3clFbx">
+            <node concept="1X3_iC" id="YzuRU63$pt" role="lGtFl">
+              <property role="3V$3am" value="statement" />
+              <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+              <node concept="3clFbF" id="YzuRU63$pu" role="8Wnug">
+                <node concept="1rXfSq" id="YzuRU63$pv" role="3clFbG">
+                  <ref role="37wK5l" node="7dExkrP$zSi" resolve="print" />
+                  <node concept="Xl_RD" id="YzuRU63$pw" role="37wK5m">
+                    <property role="Xl_RC" value="Element has no name. Skipping." />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="YzuRU63$px" role="3cqZAp" />
+          </node>
+          <node concept="17R0WA" id="YzuRU63$py" role="3clFbw">
+            <node concept="10Nm6u" id="YzuRU63$pz" role="3uHU7w" />
+            <node concept="37vLTw" id="YzuRU63$p$" role="3uHU7B">
+              <ref role="3cqZAo" node="5lAUolesrRQ" resolve="name" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="YzuRU63vsd" role="3cqZAp" />
         <node concept="3SKdUt" id="2Ttkg9nVYCK" role="3cqZAp">
           <node concept="1PaTwC" id="4OSXsDb$6sZ" role="3ndbpf">
             <node concept="3oM_SD" id="4OSXsDb$6t0" role="1PaTwD">


### PR DESCRIPTION
EAnnotations may not have names.

Adding simple return (which is already done in the parseClass method earlier too)